### PR TITLE
Issue#52: Fix hanging test teardown in WindowtesterExecutionStorage

### DIFF
--- a/com.windowtester.junit5/src/main/java/com/windowtester/junit5/WindowtesterExecutionStorage.java
+++ b/com.windowtester.junit5/src/main/java/com/windowtester/junit5/WindowtesterExecutionStorage.java
@@ -2,17 +2,36 @@ package com.windowtester.junit5;
 
 import java.awt.Component;
 import java.awt.Dialog;
+import java.awt.EventQueue;
+import java.awt.Frame;
 import java.awt.Window;
+import java.lang.System.Logger;
+import java.lang.System.Logger.Level;
+import java.lang.reflect.InvocationTargetException;
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.concurrent.TimeUnit;
+import java.util.function.BooleanSupplier;
+import java.util.stream.Collectors;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.ExtensionContext.Namespace;
 import org.junit.jupiter.api.extension.ExtensionContext.Store;
 
 public class WindowtesterExecutionStorage {
 
+  private static final Logger LOGGER =
+      System.getLogger(WindowtesterExecutionStorage.class.getName());
+
   private static final String UI_COMPONENT_KEY = "UI_COMPONENT";
   private static final String UI_CONTEXT_KEY = "UI_CONTEXT";
+
+  /**
+   * Upper bound for how long {@link #wipe()} waits for all windows to disappear before giving up, so
+   * a window that never hides cannot hang the test teardown (and the build) forever.
+   */
+  private static final Duration DISPOSAL_TIMEOUT = Duration.ofSeconds(10);
+
+  private static final Duration POLL_INTERVAL = Duration.ofMillis(100);
 
   private final Store store;
 
@@ -32,25 +51,108 @@ public class WindowtesterExecutionStorage {
 
   void wipe() {
     wipeUIComponent();
+    forceCloseAllWindows();
+    awaitDisposal(
+        WindowtesterExecutionStorage::anyWindowStillVisible,
+        WindowtesterExecutionStorage::forceCloseAllWindows,
+        DISPOSAL_TIMEOUT,
+        POLL_INTERVAL);
+    logLeftoverWindows();
+  }
 
-    Arrays.stream(Window.getWindows()).forEach(Window::dispose);
-    // Ensure disposal is complete
-    while (anyWindowStillVisible()) {
+  /**
+   * Wait until no window is visible any more, re-closing on every poll, but never block longer than
+   * {@code timeout}. A window that refuses to hide (e.g. a modal dialog left open by a failing test,
+   * or a window that will not disappear under a headless display server) must not hang this teardown
+   * and, with it, the whole build.
+   */
+  static void awaitDisposal(
+      BooleanSupplier anyWindowStillVisible,
+      Runnable closeAllWindows,
+      Duration timeout,
+      Duration pollInterval) {
+    long deadlineNanos = System.nanoTime() + timeout.toNanos();
+    while (anyWindowStillVisible.getAsBoolean()) {
+      if (System.nanoTime() - deadlineNanos >= 0) {
+        return;
+      }
       try {
-        pauseForASecond();
+        TimeUnit.MILLISECONDS.sleep(pollInterval.toMillis());
       } catch (InterruptedException ex) {
         Thread.currentThread().interrupt();
+        return;
       }
+      closeAllWindows.run();
     }
   }
 
-  private void pauseForASecond() throws InterruptedException {
-    TimeUnit.SECONDS.sleep(1);
+  /**
+   * Actively hide and dispose every window on the event dispatch thread. Doing this on the EDT (and
+   * hiding before disposing) closes windows more reliably than a bare {@link Window#dispose()} call,
+   * including modal dialogs whose nested event loop still pumps the {@code invokeAndWait} task.
+   */
+  private static void forceCloseAllWindows() {
+    runOnEventDispatchThread(
+        () -> {
+          for (Window window : Window.getWindows()) {
+            window.setVisible(false);
+            window.dispose();
+          }
+        });
+  }
+
+  private static void runOnEventDispatchThread(Runnable action) {
+    if (EventQueue.isDispatchThread()) {
+      action.run();
+      return;
+    }
+    try {
+      EventQueue.invokeAndWait(action);
+    } catch (InterruptedException ex) {
+      Thread.currentThread().interrupt();
+    } catch (InvocationTargetException ex) {
+      LOGGER.log(Level.WARNING, "Failed to close windows on the event dispatch thread", ex);
+    }
   }
 
   // Check if any window is still active
   private static boolean anyWindowStillVisible() {
     return Arrays.stream(Window.getWindows()).anyMatch(Window::isVisible);
+  }
+
+  /**
+   * Report any window that survived the teardown so a leftover window that could poison a subsequent
+   * test does not go unnoticed (rather than being closed silently, which is impossible here, or
+   * hanging the build, which is what this whole path avoids).
+   */
+  private static void logLeftoverWindows() {
+    var leftovers =
+        Arrays.stream(Window.getWindows()).filter(Window::isVisible).collect(Collectors.toList());
+    if (leftovers.isEmpty()) {
+      return;
+    }
+    var descriptions =
+        leftovers.stream()
+            .map(WindowtesterExecutionStorage::describe)
+            .collect(Collectors.joining(", "));
+    LOGGER.log(
+        Level.WARNING,
+        "{0} window(s) still visible after teardown timeout of {1}; "
+            + "they may affect subsequent tests: {2}",
+        leftovers.size(),
+        DISPOSAL_TIMEOUT,
+        descriptions);
+  }
+
+  private static String describe(Window window) {
+    var type = window.getClass().getName();
+    String title = null;
+    if (window instanceof Frame frame) {
+      title = frame.getTitle();
+    } else if (window instanceof Dialog dialog) {
+      title = dialog.getTitle();
+    }
+    return title == null || title.isBlank() ? type : type + "[" + title + "]";
   }
 
   private void wipeUIComponent() {

--- a/com.windowtester.junit5/src/test/java/com/windowtester/junit5/WindowtesterExecutionStorageTest.java
+++ b/com.windowtester.junit5/src/test/java/com/windowtester/junit5/WindowtesterExecutionStorageTest.java
@@ -1,0 +1,52 @@
+package com.windowtester.junit5;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Regression test for the teardown hang in {@link WindowtesterExecutionStorage}.
+ *
+ * <p>{@code wipe()} used to wait for all windows to disappear in an unbounded {@code while} loop. A
+ * window that never became invisible (e.g. a modal dialog left open by a failing test, or a window
+ * that would not hide under a headless display server in a Docker container on Jenkins) made that
+ * loop spin forever, hanging the test teardown and the whole build.
+ */
+class WindowtesterExecutionStorageTest {
+
+  @Test
+  void awaitDisposalGivesUpWhenAWindowNeverHides() {
+    // A window that stays visible forever must not block the teardown indefinitely.
+    assertTimeoutPreemptively(
+        Duration.ofSeconds(5),
+        () ->
+            WindowtesterExecutionStorage.awaitDisposal(
+                () -> true, // window is always still visible
+                () -> {}, // disposing has no effect
+                Duration.ofMillis(300),
+                Duration.ofMillis(50)));
+  }
+
+  @Test
+  void awaitDisposalReturnsAsSoonAsWindowsAreGone() {
+    // Report "still visible" for the first two polls, then "gone".
+    AtomicInteger visibleChecks = new AtomicInteger();
+    AtomicInteger disposeCalls = new AtomicInteger();
+
+    assertTimeoutPreemptively(
+        Duration.ofSeconds(5),
+        () ->
+            WindowtesterExecutionStorage.awaitDisposal(
+                () -> visibleChecks.getAndIncrement() < 2,
+                disposeCalls::incrementAndGet,
+                Duration.ofSeconds(10), // large timeout; must not be reached
+                Duration.ofMillis(10)));
+
+    assertEquals(3, visibleChecks.get(), "should stop polling once no window is visible");
+    assertTrue(disposeCalls.get() >= 1, "should keep re-disposing while windows remain");
+  }
+}


### PR DESCRIPTION
Problem:
After each test the extension calls wipe(), which disposed all windows and then waited for them to disappear in an unbounded `while (anyWindowStillVisible())` loop with a 1-second sleep and no timeout. If any window stayed visible - a modal dialog left open by a failing test, or a window that would not hide under the headless display server in a Docker container on Jenkins - the loop spun forever and hung the build.

Solution:
Bound the wait: keep re-closing windows while any remain, but give up after a fixed timeout so a stuck window can no longer block teardown. Closing is now done actively on the event dispatch thread (hide then dispose), which shuts windows - including modal dialogs - more reliably than a bare dispose() call. Any window that still survives the timeout is logged as a warning instead of being left silently open, since it may affect subsequent tests. The bounded wait loop is extracted into a package-private awaitDisposal() method and covered by a regression test that verifies it returns instead of hanging when a window never hides.